### PR TITLE
Added default api key type

### DIFF
--- a/auth/request/create_api_key_request.py
+++ b/auth/request/create_api_key_request.py
@@ -11,7 +11,7 @@ class ApiKeyType(Enum):
 
 class CreateApiKeyRequest(BaseModel):
     name: str
-    type: ApiKeyType
+    type: ApiKeyType = ApiKeyType.INFERENCE
 
     @validator("name")
     def check_api_key_name_format(cls, v):


### PR DESCRIPTION
In case api key type is not sent, defaults to inference api key. 